### PR TITLE
React to message 4003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Basic VT Terminal Emulator Changelog
 
 ## `3.6.0`
-- Enhancement: When the server rejects a connection due to an `allowList` restriction, the status bar now shows "Connection forbidden" instead of a generic websocket error.
-- Enhancement: Default connection settings can now be configured via `components.vt-ng2.defaults` in `zowe.yaml` (host, port), replacing the need for `ZWED_SSH_*` environment variables. Env var fallback is preserved.
+- Enhancement: When the server rejects a connection due to an `allowList` restriction, the status bar now shows "Connection forbidden" instead of a generic websocket error. ([#83](https://github.com/zowe/vt-ng2/pull/83))
 
 ## `1.0.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Basic VT Terminal Emulator Changelog
 
+## `3.6.0`
+- Enhancement: When the server rejects a connection due to an `allowList` restriction, the status bar now shows "Connection forbidden" instead of a generic websocket error.
+- Enhancement: Default connection settings can now be configured via `components.vt-ng2.defaults` in `zowe.yaml` (host, port), replacing the need for `ZWED_SSH_*` environment variables. Env var fallback is preserved.
+
 ## `1.0.0`
 
 - Breaking change: Upgrade to Angular 12, Typescript 4, and Corejs 3 to match Desktop libraries in Zowe v2. This app may no longer work in the Zowe v1 Desktop, and v2 should be used instead.

--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -211,7 +211,12 @@ export class AppComponent implements AfterViewInit {
   }
 
   private onWSError(error: TerminalWebsocketError): void {
-    let message = "Terminal closed due to websocket error. Code="+error.code;
+    let message: string;
+    if (error.code === 4003) {
+      message = "Connection forbidden: host not permitted by server allowList";
+    } else {
+      message = "Terminal closed due to websocket error. Code="+error.code;
+    }
     this.log.warn(message+", Reason="+error.reason);
     this.setError(ErrorType.websocket, message);
     this.disconnectAndUnsetTitle();


### PR DESCRIPTION
## Proposed changes

This PR depends upon the following PRs:
https://github.com/zowe/zlux-server-framework/pull/702

One enhancement to the VT terminal UI:

1. **AllowList rejection message**: When the server closes the WebSocket with code 4003 (host not in `allowList`), the status bar now displays "Connection forbidden" instead of a generic websocket error.

**Files changed:**
- `webClient/src/app/app.component.ts` — handles WS close code 4003 in `onWSError` with a "Connection forbidden" message

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have made corresponding changes to the documentation
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

**AllowList rejection UX:**
1. Configure `components.vt-ng2.allowList` in `zowe.yaml` to exclude the target host (see zlux-server-framework PR).
2. Open the VT terminal app and attempt to connect to the excluded host.
3. Verify the status bar shows "Connection forbidden" (not a raw websocket error code or blank message).


## Further comments

The 4003 close code is handled as a known application-level rejection in `onWSError`, parallel to how other known close codes are handled. No changes to connection logic — this is purely a UI message improvement.
