### PR TITLE
Fix code default to match config default

### DIFF
--- a/webClient/src/app/app.component.ts
+++ b/webClient/src/app/app.component.ts
@@ -118,8 +118,8 @@ export class AppComponent implements AfterViewInit {
 
     //defaulting initializations
     if (!this.host) this.host = "localhost";
-    if (!this.port) this.port = 23;
-    if (!this.securityType) this.securityType = "0";
+    if (!this.port) this.port = 22;
+    if (!this.securityType) this.securityType = "1";
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
This app sets variables to different values than configuration does, but configuration is picked up soon after such that these variables initial values go unused. Despite that, I'm updating them to match reality.